### PR TITLE
Added split functionality

### DIFF
--- a/gym_minigrid/envs/negated_goals.py
+++ b/gym_minigrid/envs/negated_goals.py
@@ -16,7 +16,7 @@ class EmptyEnv(MiniGridEnv):
         split = 0.8,
         mode = "TRAIN",
         types = ('key', 'ball', 'box'),
-        colors = ('red', 'green', 'blue', 'purple', 'yellow', 'grey')
+        colors = ('red', 'green', 'blue', 'purple', 'yellow', 'grey', 'black', 'cyan', 'brown', 'orange')
     ):
         self.agent_start_pos = agent_start_pos
         self.agent_start_dir = agent_start_dir
@@ -43,7 +43,7 @@ class EmptyEnv(MiniGridEnv):
         self.vocabulary = None
 
         self.split = split
-        self.mode = mode
+        self.set_mode(mode)
 
         super().__init__(
             grid_size=size,
@@ -66,19 +66,17 @@ class EmptyEnv(MiniGridEnv):
                     self.vocabulary.add(word)
         return self.vocabulary
 
-    def set_train(self):
-        self.mode = "TRAIN"
+    def set_mode(self, mode):
+        if mode not in ["TRAIN", "EVAL"]:
+            raise ValueError("Unexpected value for mode")
 
-    def set_eval(self):
-        self.mode = "EVAL"
+        self.mode = mode
 
     def compute_indices(self, length):
         if self.mode == "TRAIN":
             return 0, math.floor(self.split * length)
-        elif self.mode == "EVAL":
-            return math.floor(self.split * length), length
         else:
-            raise ValueError("Unexpected value for mode")
+            return math.floor(self.split * length), length
 
     def direct_mission(self):
         # 1. Choose a target type and color

--- a/gym_minigrid/minigrid.py
+++ b/gym_minigrid/minigrid.py
@@ -17,7 +17,11 @@ COLORS = {
     'blue'  : np.array([0, 0, 255]),
     'purple': np.array([112, 39, 195]),
     'yellow': np.array([255, 255, 0]),
-    'grey'  : np.array([100, 100, 100])
+    'grey'  : np.array([100, 100, 100]),
+    'black' : np.array([0, 0, 0]),
+    'cyan' : np.array([0, 255, 255]),
+    'brown' : np.array([139, 69, 19]),
+    'orange' : np.array([255, 99, 71])
 }
 
 COLOR_NAMES = sorted(list(COLORS.keys()))
@@ -29,7 +33,11 @@ COLOR_TO_IDX = {
     'blue'  : 2,
     'purple': 3,
     'yellow': 4,
-    'grey'  : 5
+    'grey'  : 5,
+    'black' :  6,
+    'cyan' : 7,
+    'brown'  : 8,
+    'orange' : 9 
 }
 
 IDX_TO_COLOR = dict(zip(COLOR_TO_IDX.values(), COLOR_TO_IDX.keys()))


### PR DESCRIPTION
Added the split functionality to the colors array of EmptyEnv in negated_goals. The colors get conceptually split into train and evaluation sets by limiting the indices. The usage is akin to PyTorch style **set_train()** and **set_eval()** modes. Training mode restricts the indices to **[0, len(colors) * split)** and evaluation mode restricts the indices to **[len(colors) * split, len(colors))**. It is extensible to types of objects too as the split function simply takes the length of an array as the argument.